### PR TITLE
Release_3.3.9

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -186,7 +186,15 @@ if module == "click":
         else:
             item_s = sap_b1.get_specific_item(form, item_id)
             if item.Type == 128:
-                item_s.Columns.Item(column).Click(int(row)) # Grid cell Specific click
+                # GridColumn.Click (SDK) only allows indicating whether it is a double-click (bool).
+                # It does not support right-click or other BoCellClickType values for grids.
+                ct_norm = normalize_click_type(click_type, default=0)
+                if ct_norm not in (0, 1):
+                    raise ValueError(
+                        "SAPB1 click: for Grid items (type 128) the SDK only supports ct_Regular(0) or ct_Double(1). "
+                        f"Received click_type={click_type!r} (normalized to {ct_norm})."
+                    )
+                item_s.Columns.Item(column).Click(int(row), ct_norm == 1)
             else:
                 sap_b1.do_click_grid_item(item_s, row, column, click_type)
     except Exception as e:

--- a/libs/SAPB1.py
+++ b/libs/SAPB1.py
@@ -6,7 +6,33 @@ try:
 except ImportError:
     from Queue import Queue, Empty
 
-def click_items(*arr_item, click_type = 0):
+CLICK_TYPE_MAP = {
+    # SAPbouiCOM.BoCellClickType (segun SDK Help)
+    "ct_Regular": 0,
+    "ct_Double": 1,
+    "ct_Linked": 2,
+    "ct_Collapsed": 3,
+    "ct_Right": 4,
+    "ct_RightNoBlocking": 5,
+}
+
+
+def normalize_click_type(click_type, default=0):
+    if click_type is None or click_type == "":
+        return default
+    if isinstance(click_type, bool):
+        return default
+    if isinstance(click_type, int):
+        return click_type
+    try:
+        return int(str(click_type))
+    except Exception:
+        pass
+    return CLICK_TYPE_MAP.get(str(click_type), default)
+
+
+def click_items(*arr_item, click_type=0):
+    click_type = normalize_click_type(click_type)
 
     for item in arr_item:
         item.Click(click_type)    
@@ -128,12 +154,22 @@ class SAP_B1:
     def do_click_grid_item(self, item, row, column, click_type):
         # item.Columns.Item(str(row)).Cells.Item(int(column)).Click(click_type)
         q = Queue()
-        t = Thread(target=click_items, args=(item.Columns.Item(str(column)).Cells.Item(int(row)), click_type), daemon=False)
+        t = Thread(
+            target=click_items,
+            args=(item.Columns.Item(str(column)).Cells.Item(int(row)),),
+            kwargs={"click_type": click_type},
+            daemon=False,
+        )
         t.start()
     
     def do_click_item(self, item, click_type):
         q = Queue()
-        t = Thread(target=click_items, args=(item, click_type), daemon=False)
+        t = Thread(
+            target=click_items,
+            args=(item,),
+            kwargs={"click_type": click_type},
+            daemon=False,
+        )
         t.start()
     
     def do_select_grid_item(self, item, row, column, method, val):
@@ -172,6 +208,3 @@ if __name__ == '__main__':
     #Dim bActiveItem As Boolean = oComboBox.Active
     sap_b1.sbo_application.SendKeys("{ENTER}")
     #item_valor = data_string.Columns.Item(str("V_2")).Cells.Item(int(1))
-    
-
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pr": "Com este módulo você pode automatizar SAP Business One."
   },
   "disclaimer": "THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "license": "MIT",
   "homepage": "http://rocketbot.com/",
   "linux": false,
@@ -411,6 +411,10 @@
               {
                 "title": "Click derecho",
                 "value": "ct_Right"
+              },
+              {
+                "title": "Click derecho (no bloqueante)",
+                "value": "ct_RightNoBlocking"
               },
               {
                 "title": "Click flecha de enlace",


### PR DESCRIPTION
- Add CLICK_TYPE_MAP + normalize_click_type() to support text click types (ct_Right, etc.)
- Fix threaded click helpers to pass click_type via kwargs and normalize before Click()
- Enforce Grid (Type 128) SDK limitation: only regular/double, mapping to GridColumn.Click(row, isDouble)
- Add ct_RightNoBlocking option to package.json